### PR TITLE
Added support for "*" in the specification of AllowedHeaders

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -39,6 +39,8 @@ type Options struct {
 	AllowedMethods []string
 	// AllowedHeaders is list of non simple headers the client is allowed to use with
 	// cross-domain requests. Default value is simple methods (GET and POST)
+	// If the special "*" value is present in the list, all headers will be allowed.
+	// Default value is [] but "Origin" is always appended to the list.
 	AllowedHeaders []string
 	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
 	// API specification
@@ -326,7 +328,7 @@ func (cors *Cors) areHeadersAllowed(requestedHeaders []string) bool {
 	for _, header := range requestedHeaders {
 		found := false
 		for _, allowedHeader := range cors.options.AllowedHeaders {
-			if header == allowedHeader {
+			if allowedHeader == "*" || allowedHeader == header {
 				found = true
 				break
 			}

--- a/cors_test.go
+++ b/cors_test.go
@@ -171,6 +171,30 @@ func TestAllowedHeader(t *testing.T) {
 	})
 }
 
+func TestAllowedWildcardHeader(t *testing.T) {
+	s := New(Options{
+		AllowedOrigins: []string{"http://foobar.com"},
+		AllowedHeaders: []string{"*"},
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Origin", "http://foobar.com")
+	req.Header.Add("Access-Control-Request-Method", "GET")
+	req.Header.Add("Access-Control-Request-Headers", "X-Header-2, X-HEADER-1")
+
+	s.Handler(testHandler).ServeHTTP(res, req)
+
+	assertHeaders(t, res.Header(), map[string]string{
+		"Access-Control-Allow-Origin":      "http://foobar.com",
+		"Access-Control-Allow-Methods":     "GET",
+		"Access-Control-Allow-Headers":     "X-Header-2, X-Header-1",
+		"Access-Control-Allow-Credentials": "",
+		"Access-Control-Max-Age":           "",
+		"Access-Control-Expose-Headers":    "",
+	})
+}
+
 func TestDisallowedHeader(t *testing.T) {
 	s := New(Options{
 		AllowedOrigins: []string{"http://foobar.com"},


### PR DESCRIPTION
These changes treat `"*"` as a special case (that matches any header) within the
`AllowedHeaders` array.  A test case was added to check the functionality of
this wildcard and the documentation regarding the `AllowedHeaders` field was
updated to mention this functionality as well as the automatic appending
of the `"Origin"` header (i.e., that it is not necessary to specify the
`"Origin"` header among the set of allowed headers).