### PR TITLE
don't strip out underscores in headers

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -51,7 +51,7 @@ func parseHeaderList(headerList string) []string {
 			} else {
 				h = append(h, b)
 			}
-		} else if b == '-' || (b >= '0' && b <= '9') {
+		} else if b == '-' || b == '_' || (b >= '0' && b <= '9') {
 			h = append(h, b)
 		}
 
@@ -63,7 +63,7 @@ func parseHeaderList(headerList string) []string {
 				upper = true
 			}
 		} else {
-			upper = b == '-'
+			upper = b == '-' || b == '_'
 		}
 	}
 	return headers


### PR DESCRIPTION
This adds support for underscores in headers.

There might be some finer subtleties left to address per http://tools.ietf.org/html/rfc7230#section-3.2.