### PR TITLE
Return 200 if Passthrough is disabled

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -181,6 +181,8 @@ func (c *Cors) Handler(h http.Handler) http.Handler {
 			// headers (see #1)
 			if c.optionPassthrough {
 				h.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
 			}
 		} else {
 			c.logf("Handler: Actual request")
@@ -202,6 +204,8 @@ func (c *Cors) HandlerC(h xhandler.HandlerC) xhandler.HandlerC {
 			// headers (see #1)
 			if c.optionPassthrough {
 				h.ServeHTTPC(ctx, w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
 			}
 		} else {
 			c.logf("Handler: Actual request")
@@ -233,6 +237,8 @@ func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Handl
 		// headers (see #1)
 		if c.optionPassthrough {
 			next(w, r)
+		} else {
+			w.WriteHeader(http.StatusOK)
 		}
 	} else {
 		c.logf("ServeHTTP: Actual request")


### PR DESCRIPTION
If OptionsPassthrough is set to false, returning a 200 wouldn't be harmful per discussion in https://github.com/rs/cors/issues/21