### PR TITLE
Add X-Requested-With to default AllowedHeaders

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -138,7 +138,7 @@ func New(options Options) *Cors {
 	// Allowed Headers
 	if len(options.AllowedHeaders) == 0 {
 		// Use sensible defaults
-		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type"}
+		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
 	} else {
 		// Origin is always appended as some browsers will always request for this header at preflight
 		c.allowedHeaders = convert(append(options.AllowedHeaders, "Origin"), http.CanonicalHeaderKey)

--- a/cors_test.go
+++ b/cors_test.go
@@ -243,6 +243,25 @@ func TestSpec(t *testing.T) {
 			},
 		},
 		{
+			"DefaultAllowedHeaders",
+			Options{
+				AllowedOrigins: []string{"http://foobar.com"},
+				AllowedHeaders: []string{},
+			},
+			"OPTIONS",
+			map[string]string{
+				"Origin":                         "http://foobar.com",
+				"Access-Control-Request-Method":  "GET",
+				"Access-Control-Request-Headers": "X-Requested-With",
+			},
+			map[string]string{
+				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Access-Control-Allow-Origin":  "http://foobar.com",
+				"Access-Control-Allow-Methods": "GET",
+				"Access-Control-Allow-Headers": "X-Requested-With",
+			},
+		},
+		{
 			"AllowedWildcardHeader",
 			Options{
 				AllowedOrigins: []string{"http://foobar.com"},


### PR DESCRIPTION
This header is fairly commonly set by frontend web frameworks, especially older frameworks. (for more info, see https://markitzeroday.com/x-requested-with/cors/2017/06/29/csrf-mitigation-for-ajax-requests.html)

Adding this header to the default allowed list allows these frameworks to work without any extra configuration.

Fixes #48