### PR TITLE
Fix * behavior to be standards compliant.

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -159,11 +159,6 @@ func New(options Options) *Cors {
 		c.allowedMethods = convert(options.AllowedMethods, strings.ToUpper)
 	}
 
-	if c.allowedOriginsAll && c.allowCredentials {
-		// See https://github.com/rs/cors/issues/55
-		log.Print("[cors] WARNING: unsafe configuration: AllowOrigin * and AllowCredientials true combined")
-	}
-
 	return c
 }
 
@@ -274,7 +269,7 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		c.logf("  Preflight aborted: headers '%v' not allowed", reqHeaders)
 		return
 	}
-	if c.allowedOriginsAll && !c.allowCredentials {
+	if c.allowedOriginsAll {
 		headers.Set("Access-Control-Allow-Origin", "*")
 	} else {
 		headers.Set("Access-Control-Allow-Origin", origin)
@@ -326,7 +321,7 @@ func (c *Cors) handleActualRequest(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	if c.allowedOriginsAll && !c.allowCredentials {
+	if c.allowedOriginsAll {
 		headers.Set("Access-Control-Allow-Origin", "*")
 	} else {
 		headers.Set("Access-Control-Allow-Origin", origin)

--- a/cors_test.go
+++ b/cors_test.go
@@ -83,7 +83,7 @@ func TestSpec(t *testing.T) {
 			},
 			map[string]string{
 				"Vary": "Origin",
-				"Access-Control-Allow-Origin":      "http://foobar.com",
+				"Access-Control-Allow-Origin":      "*",
 				"Access-Control-Allow-Credentials": "true",
 			},
 		},


### PR DESCRIPTION
In section 6.1 of the CORS standard is talks about this exact situation.
Even though you have built in a guard-rail in to the library which will print
a nice warning, it is preferred to rely on the security already built in to
the standard.

When ACAO: * and ACAC: true are both specified the browser will refuse to
make the credentialed request.

Refer to the standard: https://www.w3.org/TR/cors/