### PR TITLE
improve performance of wildcard domain matching

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -12,7 +12,7 @@ type wildcard struct {
 }
 
 func (w wildcard) match(s string) bool {
-	return len(s) >= len(w.prefix+w.suffix) && strings.HasPrefix(s, w.prefix) && strings.HasSuffix(s, w.suffix)
+	return len(s) >= len(w.prefix)+len(w.suffix) && strings.HasPrefix(s, w.prefix) && strings.HasSuffix(s, w.suffix)
 }
 
 // convert converts a list of string using the passed converter function

--- a/utils_test.go
+++ b/utils_test.go
@@ -68,3 +68,19 @@ func BenchmarkParseHeaderListNormalized(b *testing.B) {
 		parseHeaderList("Header1, Header2, Third-Header")
 	}
 }
+
+func BenchmarkWildcard(b *testing.B) {
+	w := wildcard{"foo", "bar"}
+	b.Run("match", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			w.match("foobazbar")
+		}
+	})
+	b.Run("too short", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			w.match("fobar")
+		}
+	})
+}


### PR DESCRIPTION
The [documentation](https://github.com/rs/cors/blob/master/cors.go#L36) implies that there's a performance penalty for using wildcards, but the performance can be improved.

Rather than concatenating two strings to find their combined length, it's quicker to just add their lengths.

Before:
```
$ go test -bench BenchmarkWildcard
goos: darwin
goarch: amd64
pkg: github.com/rs/cors
BenchmarkWildcard/match-4               50000000                25.8 ns/op             0 B/op          0 allocs/op
BenchmarkWildcard/too_short-4            100000000               20.7 ns/op             0 B/op          0 allocs/op
```
After:
```
$ go test -bench BenchmarkWildcard
goos: darwin
goarch: amd64
pkg: github.com/rs/cors
BenchmarkWildcard/match-4               200000000                7.45 ns/op            0 B/op          0 allocs/op
BenchmarkWildcard/too_short-4           2000000000               1.21 ns/op            0 B/op          0 allocs/op
```