### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -227,7 +227,7 @@ func (c *Cors) HandlerFunc(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Negroni compatible interface
+// ServeHTTP: Negroni compatible interface
 func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
 		c.logf("ServeHTTP: Preflight request")


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say "opt out" to opt out of future CodeLingo outreach PRs.*