### PR TITLE
Add CORS headers to non-preflight OPTIONS too

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -316,10 +316,6 @@ func (c *Cors) handleActualRequest(w http.ResponseWriter, r *http.Request) {
 	headers := w.Header()
 	origin := r.Header.Get("Origin")
 
-	if r.Method == http.MethodOptions {
-		c.logf("  Actual request no headers added: method == %s", r.Method)
-		return
-	}
 	// Always set Vary, see https://github.com/rs/cors/issues/10
 	headers.Add("Vary", "Origin")
 	if origin == "" {

--- a/cors_test.go
+++ b/cors_test.go
@@ -67,7 +67,7 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foobar.com",
 			},
 			map[string]string{
-				"Vary": "Origin",
+				"Vary":                        "Origin",
 				"Access-Control-Allow-Origin": "*",
 			},
 		},
@@ -82,7 +82,7 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foobar.com",
 			},
 			map[string]string{
-				"Vary": "Origin",
+				"Vary":                             "Origin",
 				"Access-Control-Allow-Origin":      "*",
 				"Access-Control-Allow-Credentials": "true",
 			},
@@ -97,7 +97,7 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foobar.com",
 			},
 			map[string]string{
-				"Vary": "Origin",
+				"Vary":                        "Origin",
 				"Access-Control-Allow-Origin": "http://foobar.com",
 			},
 		},
@@ -111,7 +111,7 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foo.bar.com",
 			},
 			map[string]string{
-				"Vary": "Origin",
+				"Vary":                        "Origin",
 				"Access-Control-Allow-Origin": "http://foo.bar.com",
 			},
 		},
@@ -153,7 +153,7 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foobar.com",
 			},
 			map[string]string{
-				"Vary": "Origin",
+				"Vary":                        "Origin",
 				"Access-Control-Allow-Origin": "http://foobar.com",
 			},
 		},
@@ -170,7 +170,7 @@ func TestSpec(t *testing.T) {
 				"Authorization": "secret",
 			},
 			map[string]string{
-				"Vary": "Origin",
+				"Vary":                        "Origin",
 				"Access-Control-Allow-Origin": "http://foobar.com",
 			},
 		},
@@ -203,7 +203,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Method": "GET",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":  "http://example.com/",
 				"Access-Control-Allow-Methods": "GET",
 				"Access-Control-Max-Age":       "10",
@@ -221,7 +221,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Method": "PUT",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":  "http://foobar.com",
 				"Access-Control-Allow-Methods": "PUT",
 			},
@@ -254,7 +254,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":  "http://foobar.com",
 				"Access-Control-Allow-Methods": "GET",
 				"Access-Control-Allow-Headers": "X-Header-2, X-Header-1",
@@ -273,7 +273,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Headers": "X-Requested-With",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":  "http://foobar.com",
 				"Access-Control-Allow-Methods": "GET",
 				"Access-Control-Allow-Headers": "X-Requested-With",
@@ -292,7 +292,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Headers": "X-Header-2, X-HEADER-1",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":  "http://foobar.com",
 				"Access-Control-Allow-Methods": "GET",
 				"Access-Control-Allow-Headers": "X-Header-2, X-Header-1",
@@ -326,7 +326,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Headers": "origin",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":  "http://foobar.com",
 				"Access-Control-Allow-Methods": "GET",
 				"Access-Control-Allow-Headers": "Origin",
@@ -343,7 +343,7 @@ func TestSpec(t *testing.T) {
 				"Origin": "http://foobar.com",
 			},
 			map[string]string{
-				"Vary": "Origin",
+				"Vary":                          "Origin",
 				"Access-Control-Allow-Origin":   "http://foobar.com",
 				"Access-Control-Expose-Headers": "X-Header-1, X-Header-2",
 			},
@@ -360,7 +360,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Method": "GET",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                             "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":      "http://foobar.com",
 				"Access-Control-Allow-Methods":     "GET",
 				"Access-Control-Allow-Credentials": "true",
@@ -377,7 +377,7 @@ func TestSpec(t *testing.T) {
 				"Access-Control-Request-Method": "GET",
 			},
 			map[string]string{
-				"Vary": "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
 				"Access-Control-Allow-Origin":  "*",
 				"Access-Control-Allow-Methods": "GET",
 			},
@@ -388,8 +388,13 @@ func TestSpec(t *testing.T) {
 				AllowedOrigins: []string{"http://foobar.com"},
 			},
 			"OPTIONS",
-			map[string]string{},
-			map[string]string{},
+			map[string]string{
+				"Origin": "http://foobar.com",
+			},
+			map[string]string{
+				"Vary":                        "Origin",
+				"Access-Control-Allow-Origin": "http://foobar.com",
+			},
 		},
 	}
 	for i := range cases {
@@ -471,19 +476,6 @@ func TestHandlePreflightNoOptionsAbortion(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
 
 	s.handlePreflight(res, req)
-
-	assertHeaders(t, res.Header(), map[string]string{})
-}
-
-func TestHandleActualRequestAbortsOptionsMethod(t *testing.T) {
-	s := New(Options{
-		AllowedOrigins: []string{"http://foo.com"},
-	})
-	res := httptest.NewRecorder()
-	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
-	req.Header.Add("Origin", "http://example.com/")
-
-	s.handleActualRequest(res, req)
 
 	assertHeaders(t, res.Header(), map[string]string{})
 }


### PR DESCRIPTION
Non preflight OPTIONS requests should work with CORS too.
This change is removing abort in actual request CORS handler for
OPTIONS request, so the client can receive the necessary headers
on such request.