### PR TITLE
Update preflight response status to http.StatusNoContent (204)

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -211,7 +211,7 @@ func (c *Cors) Handler(h http.Handler) http.Handler {
 			if c.optionPassthrough {
 				h.ServeHTTP(w, r)
 			} else {
-				w.WriteHeader(http.StatusOK)
+				w.WriteHeader(http.StatusNoContent)
 			}
 		} else {
 			c.logf("Handler: Actual request")
@@ -244,7 +244,7 @@ func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.Handl
 		if c.optionPassthrough {
 			next(w, r)
 		} else {
-			w.WriteHeader(http.StatusOK)
+			w.WriteHeader(http.StatusNoContent)
 		}
 	} else {
 		c.logf("ServeHTTP: Actual request")


### PR DESCRIPTION
Thanks for this library, it works!

When I compare this library with javascript CORS implementation, I saw they return 204 instead of 200 when user send preflight request.

Not sure whether status 200 will make browsers read the request body. It might be better to return 204?

In this PR, I change preflight status to http.StatusNoContent (204).