### PR TITLE
Updating renamed required pressly repo to go-chi

### DIFF
--- a/examples/chi/server.go
+++ b/examples/chi/server.go
@@ -3,7 +3,7 @@ package main
 import (
 	"net/http"
 
-	"github.com/pressly/chi"
+	"github.com/go-chi/chi"
 	"github.com/rs/cors"
 )
 


### PR DESCRIPTION
I did not include an updated go.mod file to minimize downstream impact; I can do so if that's preferred.