### PR TITLE
add option to allow all methods

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -47,6 +47,7 @@ type Options struct {
 	AllowOriginRequestFunc func(r *http.Request, origin string) bool
 	// AllowedMethods is a list of methods the client is allowed to use with
 	// cross-domain requests. Default value is simple methods (HEAD, GET and POST).
+	// If the special "*" value is present in the list, all methods will be allowed.
 	AllowedMethods []string
 	// AllowedHeaders is list of non simple headers the client is allowed to use with
 	// cross-domain requests.
@@ -97,6 +98,8 @@ type Cors struct {
 	allowedOriginsAll bool
 	// Set to true when allowed headers contains a "*"
 	allowedHeadersAll bool
+	// Set to true when allowed methods contains a "*"
+	allowedMethodsAll bool
 	allowCredentials  bool
 	optionPassthrough bool
 }
@@ -169,6 +172,13 @@ func New(options Options) *Cors {
 		c.allowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead}
 	} else {
 		c.allowedMethods = convert(options.AllowedMethods, strings.ToUpper)
+		for _, h := range options.AllowedMethods {
+			if h == "*" {
+				c.allowedMethodsAll = true
+				c.allowedMethods = nil
+				break
+			}
+		}
 	}
 
 	return c
@@ -392,6 +402,9 @@ func (c *Cors) isOriginAllowed(r *http.Request, origin string) bool {
 // isMethodAllowed checks if a given method can be used as part of a cross-domain request
 // on the endpoint
 func (c *Cors) isMethodAllowed(method string) bool {
+	if c.allowedMethodsAll  {
+		return true
+	}
 	if len(c.allowedMethods) == 0 {
 		// If no method allowed, always return false, even for preflight request
 		return false


### PR DESCRIPTION
This PR add a wildcard option `*` to allow all methods specified in `Access-Control-Request-Method`. I was trying to access webdav files from [organice](https://organice.200ok.ch/). My preflight request is like this `curl -vvvvvv -H 'Access-Control-Request-Method: PROPFIND' -H 'Access-Control-Request-Headers: authorization,depth' -H 'Origin: https://organice.200ok.ch' -X OPTIONS http://example.com`. There is [a few custom http verbs for webdav](https://www.ibm.com/docs/en/i/7.1?topic=concepts-webdav). I think it makes sense to allow all the http methods, so I added an option to allow all methods, just like the option to allow all http headers.