### PR TITLE
Option to specify preflight response status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ handler = c.Handler(handler)
 * **AllowCredentials** `bool`: Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates. The default is `false`.
 * **MaxAge** `int`: Indicates how long (in seconds) the results of a preflight request can be cached. The default is `0` which stands for no max age.
 * **OptionsPassthrough** `bool`: Instructs preflight to let other potential next handlers to process the `OPTIONS` method. Turn this on if your application handles `OPTIONS`.
+* **OptionsSuccessStatus** `int`: Provides a status code to use for successful OPTIONS requests. Default value is `http.StatusNoContent` (`204`).
 * **Debug** `bool`: Debugging flag adds additional output to debug server side CORS issues.
 
 See [API documentation](http://godoc.org/github.com/rs/cors) for more info.

--- a/cors.go
+++ b/cors.go
@@ -238,6 +238,8 @@ func (c *Cors) HandlerFunc(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
 		c.logf("HandlerFunc: Preflight request")
 		c.handlePreflight(w, r)
+
+		w.WriteHeader(c.optionsSuccessStatus)
 	} else {
 		c.logf("HandlerFunc: Actual request")
 		c.handleActualRequest(w, r)

--- a/cors_test.go
+++ b/cors_test.go
@@ -558,3 +558,53 @@ func TestIsMethodAllowedReturnsTrueWithOptions(t *testing.T) {
 		t.Error("IsMethodAllowed should return true when c.allowedMethods is nil.")
 	}
 }
+
+func TestOptionsSuccessStatusCodeDefault(t *testing.T) {
+	s := New(Options{
+		// Intentionally left blank.
+	})
+
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Access-Control-Request-Method", "GET")
+
+	t.Run("Handler", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		s.Handler(testHandler).ServeHTTP(res, req)
+		assertResponse(t, res, http.StatusNoContent)
+	})
+	t.Run("HandlerFunc", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		s.HandlerFunc(res, req)
+		assertResponse(t, res, http.StatusNoContent)
+	})
+	t.Run("Negroni", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		s.ServeHTTP(res, req, testHandler)
+		assertResponse(t, res, http.StatusNoContent)
+	})
+}
+
+func TestOptionsSuccessStatusCodeOverride(t *testing.T) {
+	s := New(Options{
+		OptionsSuccessStatus: http.StatusOK,
+	})
+
+	req, _ := http.NewRequest("OPTIONS", "http://example.com/foo", nil)
+	req.Header.Add("Access-Control-Request-Method", "GET")
+
+	t.Run("Handler", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		s.Handler(testHandler).ServeHTTP(res, req)
+		assertResponse(t, res, http.StatusOK)
+	})
+	t.Run("HandlerFunc", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		s.HandlerFunc(res, req)
+		assertResponse(t, res, http.StatusOK)
+	})
+	t.Run("Negroni", func(t *testing.T) {
+		res := httptest.NewRecorder()
+		s.ServeHTTP(res, req, testHandler)
+		assertResponse(t, res, http.StatusOK)
+	})
+}


### PR DESCRIPTION
## Description

In the recent version (`v1.8.0`) there was added a [change](https://github.com/rs/cors/pull/101) that potentially might break the clients that mistakenly relied on HTTP response code as `200` only (or other exotic behavior). Although, the [specification does not provide](https://fetch.spec.whatwg.org/#cors-preflight-fetch) the recommended status code for the preflight response, some of the clients ([old browsers](https://bugzilla.mozilla.org/show_bug.cgi?id=845881) and/or [SmartTVs](https://expressjs.com/en/resources/middleware/cors.html)) will choke on 204.

In this PR we provide a way to specify the status code to use for successful OPTIONS requests in a similar way it does so in [expressjs](https://expressjs.com/en/resources/middleware/cors.html).

Along with the above changes, there is also a missing status code set for the Martini compatible handler which is fixed as well.

## Related

- https://github.com/rs/cors/pull/101
- https://fetch.spec.whatwg.org/#cors-preflight-fetch
- https://bugzilla.mozilla.org/show_bug.cgi?id=845881
- https://expressjs.com/en/resources/middleware/cors.html