### PR TITLE
Use time.Duration for MaxAge

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ handler = c.Handler(handler)
 * **AllowedHeaders** `[]string`: A list of non simple headers the client is allowed to use with cross-domain requests.
 * **ExposedHeaders** `[]string`: Indicates which headers are safe to expose to the API of a CORS API specification
 * **AllowCredentials** `bool`: Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates. The default is `false`.
-* **MaxAge** `int`: Indicates how long (in seconds) the results of a preflight request can be cached. The default is `0` which stands for no max age.
+* **MaxAge** `time.Duration`: Indicates how long the results of a preflight request can be cached. The default is `0` which stands for no max age.
 * **OptionsPassthrough** `bool`: Instructs preflight to let other potential next handlers to process the `OPTIONS` method. Turn this on if your application handles `OPTIONS`.
 * **OptionsSuccessStatus** `int`: Provides a status code to use for successful OPTIONS requests. Default value is `http.StatusNoContent` (`204`).
 * **Debug** `bool`: Debugging flag adds additional output to debug server side CORS issues.

--- a/cors.go
+++ b/cors.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Options is a configuration container to setup the CORS middleware.
@@ -56,9 +57,8 @@ type Options struct {
 	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
 	// API specification
 	ExposedHeaders []string
-	// MaxAge indicates how long (in seconds) the results of a preflight request
-	// can be cached
-	MaxAge int
+	// MaxAge indicates how long the results of a preflight request can be cached
+	MaxAge time.Duration
 	// AllowCredentials indicates whether the request can include user credentials like
 	// cookies, HTTP authentication or client side SSL certificates.
 	AllowCredentials bool
@@ -95,7 +95,7 @@ type Cors struct {
 	allowedMethods []string
 	// Normalized list of exposed headers
 	exposedHeaders []string
-	maxAge         int
+	maxAge         time.Duration
 	// Set to true when allowed origins contains a "*"
 	allowedOriginsAll bool
 	// Set to true when allowed headers contains a "*"
@@ -320,7 +320,7 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		headers.Set("Access-Control-Allow-Credentials", "true")
 	}
 	if c.maxAge > 0 {
-		headers.Set("Access-Control-Max-Age", strconv.Itoa(c.maxAge))
+		headers.Set("Access-Control-Max-Age", strconv.FormatInt(int64(c.maxAge/time.Second), 10))
 	}
 	c.logf("  Preflight response headers: %v", headers)
 }

--- a/cors_test.go
+++ b/cors_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 var testHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -206,7 +207,7 @@ func TestSpec(t *testing.T) {
 			Options{
 				AllowedOrigins: []string{"http://example.com/"},
 				AllowedMethods: []string{"GET"},
-				MaxAge:         10,
+				MaxAge:         10 * time.Second,
 			},
 			"OPTIONS",
 			map[string]string{


### PR DESCRIPTION
Go has a dedicated type to express a duration: `time.Duration`. Using it simplifies the interface as it doesn't require reading up on what unit to use for the `MaxAge` parameter.

This change breaks backwards compatibility but it's trivial to fix (i.e. just add `* time.Second` to the previous configuration value). Ultimately up to you to decide if it's worth the minor inconvenience it will cause for users updating the library.