### PR TITLE
Optmize allow-headers check by removing duplicate values

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -4,15 +4,15 @@ as defined by http://www.w3.org/TR/cors/
 
 You can configure it by passing an option struct to cors.New:
 
-    c := cors.New(cors.Options{
-        AllowedOrigins:   []string{"foo.com"},
-        AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodDelete},
-        AllowCredentials: true,
-    })
+	c := cors.New(cors.Options{
+	    AllowedOrigins:   []string{"foo.com"},
+	    AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+	    AllowCredentials: true,
+	})
 
 Then insert the handler in the chain:
 
-    handler = c.Handler(handler)
+	handler = c.Handler(handler)
 
 See Options documentation for more options.
 
@@ -162,8 +162,19 @@ func New(options Options) *Cors {
 		// Use sensible defaults
 		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
 	} else {
-		// Origin is always appended as some browsers will always request for this header at preflight
-		c.allowedHeaders = convert(append(options.AllowedHeaders, "Origin"), http.CanonicalHeaderKey)
+		// Remove duplicated allowed headers
+		allowedHeadersMap := map[string]struct{}{
+			// Origin is always appended as some browsers will always request for this header at preflight
+			"Origin": {},
+		}
+		for _, h := range options.AllowedHeaders {
+			allowedHeadersMap[h] = struct{}{}
+		}
+		allowedHeadersToConvert := []string{}
+		for k := range allowedHeadersMap {
+			allowedHeadersToConvert = append(allowedHeadersToConvert, k)
+		}
+		c.allowedHeaders = convert(allowedHeadersToConvert, http.CanonicalHeaderKey)
 		for _, h := range options.AllowedHeaders {
 			if h == "*" {
 				c.allowedHeadersAll = true

--- a/cors_test.go
+++ b/cors_test.go
@@ -691,6 +691,12 @@ func TestCorsAreHeadersAllowed(t *testing.T) {
 			requestedHeaders: parseHeaderList("X-PINGOTHER, Content-Type"),
 			want:             false,
 		},
+		{
+			name:             "no repeated headers",
+			allowedHeaders:   []string{"Origin", "Origin", "Origin", "Content-Type", "Content-Type"},
+			requestedHeaders: parseHeaderList("Origin, Content-Type"),
+			want:             true,
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
Prevents having an Allowed list with repeated values to iterate over.

Example: 
When configuring "Origin" as an Allowed header, the list would be comprised of:  []string{"Origin","Origin"}, lead to an unnecessary additional loop.