### PR TITLE
Fix Access-Control-Request-Headers parsing issue for AWS API Gateway

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -305,7 +305,12 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 		c.logf("  Preflight aborted: method '%s' not allowed", reqMethod)
 		return
 	}
-	reqHeaders := parseHeaderList(r.Header.Get("Access-Control-Request-Headers"))
+	// Amazon API Gateway is sometimes feeding multiple values for
+	// Access-Control-Request-Headers in a way where r.Header.Values() picks
+	// them all up, but r.Header.Get() does not.
+	// I suspect it is something like this: https://stackoverflow.com/a/4371395
+	reqHeaderList := strings.Join(r.Header.Values("Access-Control-Request-Headers"), ",")
+	reqHeaders := parseHeaderList(reqHeaderList)
 	if !c.areHeadersAllowed(reqHeaders) {
 		c.logf("  Preflight aborted: headers '%v' not allowed", reqHeaders)
 		return


### PR DESCRIPTION
Quick fix for an issue where it was not always picking up all of the Access-Control-Request-Headers.  I'll clean this up a bit more in the coming days.