### PR TITLE
doc comments ServeHTTP, OriginAllowed: Match Go style

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -251,7 +251,8 @@ func (c *Cors) HandlerFunc(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Negroni compatible interface
+// ServeHTTP is a Negroni compatible interface. See:
+// https://pkg.go.dev/github.com/codegangsta/negroni
 func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
 		c.logf("ServeHTTP: Preflight request")
@@ -387,7 +388,8 @@ func (c *Cors) logf(format string, a ...interface{}) {
 	}
 }
 
-// check the Origin of a request. No origin at all is also allowed.
+// OriginAllowed checks the Origin of a request, returning true if the Origin is permitted.
+// No origin at all is also allowed.
 func (c *Cors) OriginAllowed(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	return c.isOriginAllowed(r, origin)


### PR DESCRIPTION
The Go documentation style wants public methods to repeat the name. While is redundant, it makes the documentation match other Go packages. This fixes staticcheck warnings:
```
cors.go:254:1: comment on exported method ServeHTTP should be of the form "ServeHTTP ..." (ST1020)
cors.go:390:1: comment on exported method OriginAllowed should be of the form "OriginAllowed ..." (ST1020)
```