### PR TITLE
allow logger to be specified in options

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -73,6 +73,8 @@ type Options struct {
 	OptionsSuccessStatus int
 	// Debugging flag adds additional output to debug server side CORS issues
 	Debug bool
+	// Adds a custom logger, implies Debug is true
+	Logger Logger
 }
 
 // Logger generic interface for logger
@@ -120,6 +122,7 @@ func New(options Options) *Cors {
 		allowPrivateNetwork:    options.AllowPrivateNetwork,
 		maxAge:                 options.MaxAge,
 		optionPassthrough:      options.OptionsPassthrough,
+		Log:                    options.Logger,
 	}
 	if options.Debug && c.Log == nil {
 		c.Log = log.New(os.Stdout, "[cors] ", log.LstdFlags)

--- a/cors_test.go
+++ b/cors_test.go
@@ -1,6 +1,8 @@
 package cors
 
 import (
+	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -502,6 +504,29 @@ func TestDebug(t *testing.T) {
 
 	if s.Log == nil {
 		t.Error("Logger not created when debug=true")
+	}
+}
+
+type testLogger struct {
+	buf *bytes.Buffer
+}
+
+func (l *testLogger) Printf(format string, v ...interface{}) {
+	fmt.Fprintf(l.buf, format, v...)
+}
+
+func TestLogger(t *testing.T) {
+	logger := &testLogger{buf: &bytes.Buffer{}}
+	s := New(Options{
+		Logger: logger,
+	})
+
+	if s.Log == nil {
+		t.Error("Logger not created when Logger is set")
+	}
+	s.logf("test")
+	if logger.buf.String() != "test" {
+		t.Error("Logger not used")
 	}
 }
 


### PR DESCRIPTION
This just adds a convenience field to the Options for specifying the logger.
It removes the need to explicitely set the logger field after creation.