### PR TITLE
Listing Origin as an allowed request header is unnecessary

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -163,10 +163,9 @@ func New(options Options) *Cors {
 	// Allowed Headers
 	if len(options.AllowedHeaders) == 0 {
 		// Use sensible defaults
-		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
+		c.allowedHeaders = []string{"Accept", "Content-Type", "X-Requested-With"}
 	} else {
-		// Origin is always appended as some browsers will always request for this header at preflight
-		c.allowedHeaders = convert(append(options.AllowedHeaders, "Origin"), http.CanonicalHeaderKey)
+		c.allowedHeaders = convert(options.AllowedHeaders, http.CanonicalHeaderKey)
 		for _, h := range options.AllowedHeaders {
 			if h == "*" {
 				c.allowedHeadersAll = true

--- a/cors_test.go
+++ b/cors_test.go
@@ -336,25 +336,6 @@ func TestSpec(t *testing.T) {
 			true,
 		},
 		{
-			"OriginHeader",
-			Options{
-				AllowedOrigins: []string{"http://foobar.com"},
-			},
-			"OPTIONS",
-			map[string]string{
-				"Origin":                         "http://foobar.com",
-				"Access-Control-Request-Method":  "GET",
-				"Access-Control-Request-Headers": "origin",
-			},
-			map[string]string{
-				"Vary":                         "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
-				"Access-Control-Allow-Origin":  "http://foobar.com",
-				"Access-Control-Allow-Methods": "GET",
-				"Access-Control-Allow-Headers": "Origin",
-			},
-			true,
-		},
-		{
 			"ExposedHeader",
 			Options{
 				AllowedOrigins: []string{"http://foobar.com"},


### PR DESCRIPTION
Fixes #151 

Removes the unnecessary Origin header.