### PR TITLE
Fix skewed middleware benchmarks

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -35,6 +35,7 @@ func BenchmarkWithout(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		clear(res.header)
 		testHandler.ServeHTTP(res, req)
 	}
 }
@@ -48,6 +49,7 @@ func BenchmarkDefault(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		clear(res.header)
 		handler.ServeHTTP(res, req)
 	}
 }
@@ -64,6 +66,7 @@ func BenchmarkAllowedOrigin(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		clear(res.header)
 		handler.ServeHTTP(res, req)
 	}
 }
@@ -78,6 +81,7 @@ func BenchmarkPreflight(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		clear(res.header)
 		handler.ServeHTTP(res, req)
 	}
 }
@@ -93,6 +97,13 @@ func BenchmarkPreflightHeader(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		clear(res.header)
 		handler.ServeHTTP(res, req)
+	}
+}
+
+func clear(h http.Header) {
+	for k := range h {
+		delete(h, k)
 	}
 }


### PR DESCRIPTION
I  noticed two distinct problems in `bench_test.go`.

## Missing `Origin` header in preflight requests

The `Origin` header is missing from the preflight request in two benchmarks: [`BenchmarkPreflight`][preflight] and [`BenchmarkPreflightHeader`][preflight-header]. As a result, those benchmarks don't really exercise the middleware's preflight logic.

## Re-use of the response object skews benchmarks

In a given benchmark, [a `FakeResponse` object gets re-used across iterations][reused-resp]. Accordingly, at the end of a benchmark, the response's headers contain a `"Vary"` key associated to a huge slice of strings (with `"Origin"` repeated many times); this is evident if you add the following statement right after the benchmark loop:

```go
fmt.Println(res.header)
```

Of course, because `net/http` does not re-use response objects from one handler invocation to the next, those benchmarks are not realistic. More specifically, re-using a `http.Header` map across benchmark iterations yields skewed results, because the cost of adding an element to the slice of strings associated to key `"Vary"` is amortised by `append` (which `http.Header.Add` uses under the hood). Therefore, the benchmark results look better than they realistically should.

A simple solution is to clear the `FakeResponse.header` map at the beginning of each benchmark iteration. I've added a small helper to do that, while we wait for [the new `clear` builtin promised by Go 1.21][clear].

## New benchmark results

I have not updated the [Benchmarks][bench-README] section of the README (you may want to do that yourself after running the benchmarks on your own machine), but here are the results I typically get on my old Macbook Pro:

```shell
$ go test -benchmem -run '^$' -bench '^(BenchmarkWithout|BenchmarkDefault|BenchmarkAllowedOrigin|BenchmarkPreflight|BenchmarkPreflightHeader)$'
```

```txt
goos: darwin
goarch: amd64
pkg: github.com/rs/cors
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
BenchmarkWithout-8            67202618         16.70 ns/op         3 B/op        1 allocs/op
BenchmarkDefault-8             3527163         340.9 ns/op        51 B/op        4 allocs/op
BenchmarkAllowedOrigin-8       3140804         383.6 ns/op        51 B/op        4 allocs/op
BenchmarkPreflight-8           1291208         966.7 ns/op       160 B/op        6 allocs/op
BenchmarkPreflightHeader-8      944126          1299 ns/op       208 B/op       10 allocs/op
```

[bench-README]: https://github.com/rs/cors#benchmarks
[clear]: https://tip.golang.org/doc/go1.21#language
[preflight]: https://github.com/rs/cors/blob/e90f167479505c4dbe1161306c3c977f162c1442/bench_test.go#L63
[preflight-header]: https://github.com/rs/cors/blob/e90f167479505c4dbe1161306c3c977f162c1442/bench_test.go#L76
[reused-resp]: https://github.com/rs/cors/blob/e90f167479505c4dbe1161306c3c977f162c1442/bench_test.go#L35