### PR TITLE
Normalize allowed request headers and store them in a sorted set (fixes #170)

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -88,7 +88,7 @@ func BenchmarkPreflightHeader(b *testing.B) {
 	req, _ := http.NewRequest(http.MethodOptions, dummyEndpoint, nil)
 	req.Header.Add(headerOrigin, dummyOrigin)
 	req.Header.Add(headerACRM, http.MethodGet)
-	req.Header.Add(headerACRH, "Accept")
+	req.Header.Add(headerACRH, "accept")
 	handler := Default().Handler(testHandler)
 
 	b.ReportAllocs()

--- a/bench_test.go
+++ b/bench_test.go
@@ -2,6 +2,7 @@ package cors
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -88,6 +89,21 @@ func BenchmarkPreflightHeader(b *testing.B) {
 	req.Header.Add(headerOrigin, dummyOrigin)
 	req.Header.Add(headerACRM, http.MethodGet)
 	req.Header.Add(headerACRH, "Accept")
+	handler := Default().Handler(testHandler)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		handler.ServeHTTP(resps[i], req)
+	}
+}
+
+func BenchmarkPreflightAdversarialACRH(b *testing.B) {
+	resps := makeFakeResponses(b.N)
+	req, _ := http.NewRequest(http.MethodOptions, dummyEndpoint, nil)
+	req.Header.Add(headerOrigin, dummyOrigin)
+	req.Header.Add(headerACRM, http.MethodGet)
+	req.Header.Add(headerACRH, strings.Repeat(",", 1024))
 	handler := Default().Handler(testHandler)
 
 	b.ReportAllocs()

--- a/internal/sortedset.go
+++ b/internal/sortedset.go
@@ -20,18 +20,21 @@ type SortedSet struct {
 // but no other elements.
 func NewSortedSet(elems ...string) SortedSet {
 	sort.Strings(elems)
-	elems = compact(elems)
 	m := make(map[string]int)
 	var maxLen int
-	for i, s := range elems {
-		maxLen = max(maxLen, len(s))
+	i := 0
+	for _, s := range elems {
+		if _, exists := m[s]; exists {
+			continue
+		}
 		m[s] = i
+		i++
+		maxLen = max(maxLen, len(s))
 	}
-	res := SortedSet{
+	return SortedSet{
 		m:      m,
 		maxLen: maxLen,
 	}
-	return res
 }
 
 // Size returns the cardinality of set.
@@ -89,29 +92,6 @@ func (set SortedSet) Subsumes(csv string) bool {
 		csv = csv[comma+1:]
 	}
 	return true
-}
-
-// adapted from https://pkg.go.dev/slices#Compact
-// TODO: when updating go directive to 1.21 or later,
-// use slices.Compact instead.
-func compact(s []string) []string {
-	if len(s) < 2 {
-		return s
-	}
-	i := 1
-	for k := 1; k < len(s); k++ {
-		if s[k] != s[k-1] {
-			if i != k {
-				s[i] = s[k]
-			}
-			i++
-		}
-	}
-	// zero/nil out the obsolete elements, for GC
-	for j := i; j < len(s); j++ {
-		s[j] = ""
-	}
-	return s[:i]
 }
 
 // TODO: when updating go directive to 1.21 or later,

--- a/internal/sortedset.go
+++ b/internal/sortedset.go
@@ -1,0 +1,133 @@
+// adapted from github.com/jub0bs/cors
+package internal
+
+import (
+	"sort"
+	"strings"
+)
+
+// A SortedSet represents a mathematical set of strings sorted in
+// lexicographical order.
+// Each element has a unique position ranging from 0 (inclusive)
+// to the set's cardinality (exclusive).
+// The zero value represents an empty set.
+type SortedSet struct {
+	m      map[string]int
+	maxLen int
+}
+
+// NewSortedSet returns a SortedSet that contains all of elems,
+// but no other elements.
+func NewSortedSet(elems ...string) SortedSet {
+	sort.Strings(elems)
+	elems = compact(elems)
+	m := make(map[string]int)
+	var maxLen int
+	for i, s := range elems {
+		maxLen = max(maxLen, len(s))
+		m[s] = i
+	}
+	res := SortedSet{
+		m:      m,
+		maxLen: maxLen,
+	}
+	return res
+}
+
+// Size returns the cardinality of set.
+func (set SortedSet) Size() int {
+	return len(set.m)
+}
+
+// String sorts joins the elements of set (in lexicographical order)
+// with a comma and returns the resulting string.
+func (set SortedSet) String() string {
+	elems := make([]string, len(set.m))
+	for elem, i := range set.m {
+		elems[i] = elem // safe indexing, by construction of SortedSet
+	}
+	return strings.Join(elems, ",")
+}
+
+// Subsumes reports whether csv is a sequence of comma-separated names that are
+//   - all elements of set,
+//   - sorted in lexicographically order,
+//   - unique.
+func (set SortedSet) Subsumes(csv string) bool {
+	if csv == "" {
+		return true
+	}
+	posOfLastNameSeen := -1
+	chunkSize := set.maxLen + 1 // (to accommodate for at least one comma)
+	for {
+		// As a defense against maliciously long names in csv,
+		// we only process at most chunkSize bytes per iteration.
+		end := min(len(csv), chunkSize)
+		comma := strings.IndexByte(csv[:end], ',')
+		var name string
+		if comma == -1 {
+			name = csv
+		} else {
+			name = csv[:comma]
+		}
+		pos, found := set.m[name]
+		if !found {
+			return false
+		}
+		// The names in csv are expected to be sorted in lexicographical order
+		// and appear at most once in csv.
+		// Therefore, the positions (in set) of the names that
+		// appear in csv should form a strictly increasing sequence.
+		// If that's not actually the case, bail out.
+		if pos <= posOfLastNameSeen {
+			return false
+		}
+		posOfLastNameSeen = pos
+		if comma < 0 { // We've now processed all the names in csv.
+			break
+		}
+		csv = csv[comma+1:]
+	}
+	return true
+}
+
+// adapted from https://pkg.go.dev/slices#Compact
+// TODO: when updating go directive to 1.21 or later,
+// use slices.Compact instead.
+func compact(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+	i := 1
+	for k := 1; k < len(s); k++ {
+		if s[k] != s[k-1] {
+			if i != k {
+				s[i] = s[k]
+			}
+			i++
+		}
+	}
+	// zero/nil out the obsolete elements, for GC
+	for j := i; j < len(s); j++ {
+		s[j] = ""
+	}
+	return s[:i]
+}
+
+// TODO: when updating go directive to 1.21 or later,
+// use min builtin instead.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// TODO: when updating go directive to 1.21 or later,
+// use max builtin instead.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/sortedset_test.go
+++ b/internal/sortedset_test.go
@@ -1,0 +1,119 @@
+package internal
+
+import (
+	"testing"
+)
+
+func TestSortedSet(t *testing.T) {
+	cases := []struct {
+		desc       string
+		elems      []string
+		combined   string
+		subsets    []string
+		notSubsets []string
+		wantSize   int
+	}{
+		{
+			desc:     "empty set",
+			combined: "",
+			notSubsets: []string{
+				"bar",
+				"bar,foo",
+			},
+			wantSize: 0,
+		}, {
+			desc:     "singleton set",
+			elems:    []string{"foo"},
+			combined: "foo",
+			subsets: []string{
+				"",
+				"foo",
+			},
+			notSubsets: []string{
+				"bar",
+				"bar,foo",
+			},
+			wantSize: 1,
+		}, {
+			desc:     "no dupes",
+			elems:    []string{"foo", "bar", "baz"},
+			combined: "bar,baz,foo",
+			subsets: []string{
+				"",
+				"bar",
+				"baz",
+				"foo",
+				"bar,baz",
+				"bar,foo",
+				"baz,foo",
+				"bar,baz,foo",
+			},
+			notSubsets: []string{
+				"qux",
+				"bar,baz,baz",
+				"qux,baz",
+				"qux,foo",
+				"quxbaz,foo",
+			},
+			wantSize: 3,
+		}, {
+			desc:     "some dupes",
+			elems:    []string{"foo", "bar", "bar", "foo", "e"},
+			combined: "bar,e,foo",
+			subsets: []string{
+				"",
+				"bar",
+				"e",
+				"foo",
+				"bar,foo",
+				"bar,e",
+				"e,foo",
+				"bar,e,foo",
+			},
+			notSubsets: []string{
+				"qux",
+				"qux,bar",
+				"qux,foo",
+				"qux,baz,foo",
+			},
+			wantSize: 3,
+		},
+	}
+	for _, tc := range cases {
+		f := func(t *testing.T) {
+			elems := clone(tc.elems)
+			s := NewSortedSet(tc.elems...)
+			size := s.Size()
+			if s.Size() != tc.wantSize {
+				const tmpl = "NewSortedSet(%#v...).Size(): got %d; want %d"
+				t.Errorf(tmpl, elems, size, tc.wantSize)
+			}
+			combined := s.String()
+			if combined != tc.combined {
+				const tmpl = "NewSortedSet(%#v...).String(): got %q; want %q"
+				t.Errorf(tmpl, elems, combined, tc.combined)
+			}
+			for _, sub := range tc.subsets {
+				if !s.Subsumes(sub) {
+					const tmpl = "%q is not a subset of %q, but should be"
+					t.Errorf(tmpl, sub, s)
+				}
+			}
+			for _, notSub := range tc.notSubsets {
+				if s.Subsumes(notSub) {
+					const tmpl = "%q is a subset of %q, but should not be"
+					t.Errorf(tmpl, notSub, s)
+				}
+			}
+		}
+		t.Run(tc.desc, f)
+	}
+}
+
+// adapted from https://pkg.go.dev/slices#Clone
+// TODO: when updating go directive to 1.21 or later,
+// use slices.Clone instead.
+func clone(s []string) []string {
+	// The s[:0:0] preserves nil in case it matters.
+	return append(s[:0:0], s...)
+}

--- a/utils.go
+++ b/utils.go
@@ -11,7 +11,9 @@ type wildcard struct {
 }
 
 func (w wildcard) match(s string) bool {
-	return len(s) >= len(w.prefix)+len(w.suffix) && strings.HasPrefix(s, w.prefix) && strings.HasSuffix(s, w.suffix)
+	return len(s) >= len(w.prefix)+len(w.suffix) &&
+		strings.HasPrefix(s, w.prefix) &&
+		strings.HasSuffix(s, w.suffix)
 }
 
 // convert converts a list of string using the passed converter function

--- a/utils.go
+++ b/utils.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 )
 
-type converter func(string) string
-
 type wildcard struct {
 	prefix string
 	suffix string
@@ -17,29 +15,12 @@ func (w wildcard) match(s string) bool {
 }
 
 // convert converts a list of string using the passed converter function
-func convert(s []string, c converter) []string {
-	out, _ := convertDidCopy(s, c)
-	return out
-}
-
-// convertDidCopy is same as convert but returns true if it copied the slice
-func convertDidCopy(s []string, c converter) ([]string, bool) {
-	out := s
-	copied := false
-	for i, v := range s {
-		if !copied {
-			v2 := c(v)
-			if v2 != v {
-				out = make([]string, len(s))
-				copy(out, s[:i])
-				out[i] = v2
-				copied = true
-			}
-		} else {
-			out[i] = c(v)
-		}
+func convert(s []string, f func(string) string) []string {
+	out := make([]string, len(s))
+	for i := range s {
+		out[i] = f(s[i])
 	}
-	return out, copied
+	return out
 }
 
 func first(hdrs http.Header, k string) ([]string, bool) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,7 +1,6 @@
 package cors
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -21,41 +20,6 @@ func TestWildcard(t *testing.T) {
 	w = wildcard{"foo", "oof"}
 	if w.match("foof") {
 		t.Error("foo*oof should not match foof")
-	}
-}
-
-func TestSplitHeaderValues(t *testing.T) {
-	testCases := []struct {
-		input    []string
-		expected []string
-	}{
-		{
-			input:    []string{},
-			expected: []string{},
-		},
-		{
-			input:    []string{"foo"},
-			expected: []string{"foo"},
-		},
-		{
-			input:    []string{"foo, bar, baz"},
-			expected: []string{"foo", "bar", "baz"},
-		},
-		{
-			input:    []string{"abc", "def, ghi", "jkl"},
-			expected: []string{"abc", "def", "ghi", "jkl"},
-		},
-		{
-			input:    []string{"foo, bar", "baz, qux", "quux, corge"},
-			expected: []string{"foo", "bar", "baz", "qux", "quux", "corge"},
-		},
-	}
-
-	for _, testCase := range testCases {
-		output := splitHeaderValues(testCase.input)
-		if !reflect.DeepEqual(output, testCase.expected) {
-			t.Errorf("Input: %v, Expected: %v, Got: %v", testCase.input, testCase.expected, output)
-		}
 	}
 }
 


### PR DESCRIPTION
## Proposed solution to issue #170 

The [Fetch standard](https://fetch.spec.whatwg.org/) provides several guarantees that we can take advantage of:

- preflight requests contain at most one `Access-Control-Request-Headers` header (called ACRH below);
- the names of HTTP headers, at least in the context of the CORS protocol, are case-insensitive;
- the values listed in ACRH are lowercase;
- the values listed in ACRH are unique;
- the values listed in ACRH are sorted in lexicographical order.

Therefore,

- ~we can ignore ACRH headers beyond the first one (if any);~ see #184
- we can lowercase the allowed request headers and store the results in a sorted set (rather than in a slice).

This is the approach I followed in [jub0bs/cors](https://github.com/jub0bs/cors). 😇 

## Benchmarks

Here's a benchmark comparison between before (commit ad0e722) and after my fix:

Looks like a net win:

```txt
goos: darwin
goarch: amd64
pkg: github.com/rs/cors
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
                           │     before     │                 after                 │
                           │     sec/op     │    sec/op      vs base                │
Without-8                      5.290n ± 15%    4.528n ± 31%        ~ (p=0.183 n=10)
Default-8                      92.34n ±  3%    95.86n ±  3%   +3.81% (p=0.043 n=10)
AllowedOrigin-8                126.8n ±  5%    128.6n ±  3%        ~ (p=0.541 n=10)
Preflight-8                    308.3n ±  1%    295.8n ±  1%   -4.07% (p=0.000 n=10)
PreflightHeader-8              366.5n ±  1%    333.4n ±  5%   -9.02% (p=0.000 n=10)
PreflightAdversarialACRH-8   33214.5n ±  0%    360.9n ±  4%  -98.91% (p=0.000 n=10)
Wildcard/match-8               9.723n ± 16%    9.919n ± 12%        ~ (p=0.225 n=10)
Wildcard/too_short-8          0.9875n ±  0%   0.9923n ±  0%   +0.48% (p=0.034 n=10)
geomean                        82.91n          45.86n        -44.69%

                           │     before      │                after                 │
                           │      B/op       │    B/op     vs base                  │
Without-8                       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Default-8                       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
AllowedOrigin-8                 0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Preflight-8                     0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
PreflightHeader-8               0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
PreflightAdversarialACRH-8   36904.00 ± 0%     32.00 ± 0%  -99.91% (p=0.000 n=10)
Wildcard/match-8                0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Wildcard/too_short-8            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                    ²               -58.58%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                           │    before    │                after                 │
                           │  allocs/op   │ allocs/op   vs base                  │
Without-8                    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Default-8                    0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
AllowedOrigin-8              0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Preflight-8                  0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
PreflightHeader-8            0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
PreflightAdversarialACRH-8   4.000 ± 0%     2.000 ± 0%  -50.00% (p=0.000 n=10)
Wildcard/match-8             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
Wildcard/too_short-8         0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                                 ²                -8.30%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```