### PR TITLE
`SortedSet.Subsumes` bug

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -299,6 +299,7 @@ func TestSpec(t *testing.T) {
 			},
 			true,
 		},
+		///
 		{
 			"AllowedHeaders",
 			Options{
@@ -763,4 +764,34 @@ func TestAccessControlExposeHeadersPresence(t *testing.T) {
 		})
 	}
 
+}
+
+func TestFoo(t *testing.T) {
+	const fooHeader = "FOO"
+
+	s := New(Options{
+		AllowedMethods:   []string{http.MethodOptions},
+		AllowedHeaders:   []string{fooHeader},
+		AllowCredentials: true,
+	})
+
+	responseRecorder := httptest.NewRecorder()
+
+	req, _ := http.NewRequest(http.MethodOptions, "https://example.com/foo", nil)
+	req.Header.Add("Origin", "https://example.com/")
+	req.Header.Add("Access-Control-Request-Method", http.MethodOptions)
+	req.Header.Add("Access-Control-Request-Headers", fooHeader)
+
+	s.handlePreflight(responseRecorder, req)
+
+	f := responseRecorder.Result()
+	fmt.Println("headers", f.Header)
+
+	if expected := "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"; f.Header.Get("Vary") != expected {
+		t.Errorf("Vary header expected %q, got %q", expected, f.Header.Get("Vary"))
+	}
+
+	if expected := fooHeader; f.Header.Get("Access-Control-Request-Headers") != expected {
+		t.Errorf("Vary header expected %q, got %q", expected, f.Header.Get("Access-Control-Request-Headers"))
+	}
 }

--- a/cors_test.go
+++ b/cors_test.go
@@ -763,35 +763,34 @@ func TestAccessControlExposeHeadersPresence(t *testing.T) {
 			})
 		})
 	}
-
 }
 
-func TestFoo(t *testing.T) {
-	const fooHeader = "FOO"
+func Test_CORSPreFlight_NotFailingForCustomACRHeader(t *testing.T) {
+	const apiKeyHeader = "X-Key-Api"
 
-	s := New(Options{
-		AllowedMethods:   []string{http.MethodOptions},
-		AllowedHeaders:   []string{fooHeader},
+	crs := New(Options{
+		AllowedMethods:   []string{http.MethodGet},
+		AllowedHeaders:   []string{apiKeyHeader},
 		AllowCredentials: true,
 	})
 
 	responseRecorder := httptest.NewRecorder()
 
-	req, _ := http.NewRequest(http.MethodOptions, "https://example.com/foo", nil)
-	req.Header.Add("Origin", "https://example.com/")
-	req.Header.Add("Access-Control-Request-Method", http.MethodOptions)
-	req.Header.Add("Access-Control-Request-Headers", fooHeader)
+	req, _ := http.NewRequest(http.MethodOptions, "https://example.com", nil)
+	req.Header.Add("Origin", "https://example.com")
+	req.Header.Add("Access-Control-Request-Method", http.MethodGet)
+	req.Header.Add("Access-Control-Request-Headers", apiKeyHeader)
 
-	s.handlePreflight(responseRecorder, req)
+	crs.handlePreflight(responseRecorder, req)
 
 	f := responseRecorder.Result()
 	fmt.Println("headers", f.Header)
 
-	if expected := "Origin, Access-Control-Request-Method, Access-Control-Request-Headers"; f.Header.Get("Vary") != expected {
+	if expected, actual := "Origin, Access-Control-Request-Method, Access-Control-Request-Headers", f.Header.Get("Vary"); expected != actual {
 		t.Errorf("Vary header expected %q, got %q", expected, f.Header.Get("Vary"))
 	}
 
-	if expected := fooHeader; f.Header.Get("Access-Control-Request-Headers") != expected {
+	if expected, actual := apiKeyHeader, f.Header.Get("Access-Control-Allow-Headers"); expected != actual {
 		t.Errorf("Vary header expected %q, got %q", expected, f.Header.Get("Access-Control-Request-Headers"))
 	}
 }

--- a/internal/sortedset.go
+++ b/internal/sortedset.go
@@ -60,6 +60,10 @@ func (set SortedSet) Subsumes(csv string) bool {
 	if csv == "" {
 		return true
 	}
+
+	// probably temporary.
+	csv = strings.ToLower(csv)
+
 	posOfLastNameSeen := -1
 	chunkSize := set.maxLen + 1 // (to accommodate for at least one comma)
 	for {


### PR DESCRIPTION
There seems to be a bug in [`SortedSet.Subsumes`](https://github.com/slash3b/cors/blob/f7790307763a51de207d5cde48c858798da0a6d0/internal/sortedset.go#L60) method — although the HTTP header supplied as `csv` argument to `.Subsumes` method really _is_ present in the set, `.Subsumes` returns `false` for an uppercase HTTP header. 