### PR TITLE
Remove redundant method check

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -330,10 +330,6 @@ func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	headers := w.Header()
 	origin := r.Header.Get("Origin")
 
-	if r.Method != http.MethodOptions {
-		c.logf("  Preflight aborted: %s!=OPTIONS", r.Method)
-		return
-	}
 	// Always set Vary headers
 	// see https://github.com/rs/cors/issues/10,
 	//     https://github.com/rs/cors/commit/dbdca4d95feaa7511a46e6f1efb3b3aa505bc43f#commitcomment-12352001

--- a/cors_test.go
+++ b/cors_test.go
@@ -666,18 +666,6 @@ func TestHandlePreflightInvalidOriginAbortion(t *testing.T) {
 	})
 }
 
-func TestHandlePreflightNoOptionsAbortion(t *testing.T) {
-	s := New(Options{
-		// Intentionally left blank.
-	})
-	res := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
-
-	s.handlePreflight(res, req)
-
-	assertHeaders(t, res.Header(), http.Header{})
-}
-
 func TestHandleActualRequestInvalidOriginAbortion(t *testing.T) {
 	s := New(Options{
 		AllowedOrigins: []string{"http://foo.com"},


### PR DESCRIPTION
This PR removes the redundant `r.Method != http.MethodOptions` check from `handlePreflight`.

Fixes #207