### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/examples/martini/server.go
+++ b/examples/martini/server.go
@@ -16,7 +16,7 @@ func main() {
 	m.Use(c.HandlerFunc)
 
 	m.Get("/", func(r render.Render) {
-		r.JSON(200, map[string]interface{}{"hello": "world"})
+		r.JSON(200, map[string]any{"hello": "world"})
 	})
 
 	m.Run()


### PR DESCRIPTION
Replace `interface{}` with `any` (Go 1.18+ alias) in `examples/martini/server.go`.